### PR TITLE
Update copyright to 'Groq LLC' and bump year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Groq, Inc.
+Copyright (c) 2026 Groq LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,7 +1,7 @@
 appId: com.groq.desktop
 productName: Groq Desktop
 artifactName: "${productName}-${version}.${ext}"
-copyright: "Copyright © 2025 Groq"
+copyright: "Copyright © 2026 Groq LLC"
 
 directories:
   buildResources: build


### PR DESCRIPTION
## Branding / legal-name cleanup
Updates copyright/branding text to the current legal entity **`Groq LLC`** and bumps the year to **2026**.
Files changed:
- `LICENSE`
Scope: copyright / license / footer branding only. Contracts, legal agreements, trademark notices, and legal-entity-name fields were excluded for manual legal review.